### PR TITLE
Show "You" label for current user and track custom name status

### DIFF
--- a/lib/tomato_web/live/room_live.ex
+++ b/lib/tomato_web/live/room_live.ex
@@ -177,7 +177,7 @@ defmodule TomatoWeb.RoomLive do
               >
                 <p class="text-xs font-medium truncate">
                   <%= if uid == @user_id do %>
-                    <%= if @has_custom_name, do: "#{member.display_name} (You)", else: "You" %>
+                    <%= if @has_custom_name, do: "#{@display_name} (You)", else: "You" %>
                   <% else %>
                     {member.display_name}
                   <% end %>

--- a/test/tomato_web/live/room_live_test.exs
+++ b/test/tomato_web/live/room_live_test.exs
@@ -107,6 +107,21 @@ defmodule TomatoWeb.RoomLiveTest do
     refute initial_html == updated_html
   end
 
+  test "skipping name modal shows 'You' on current user's card", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/room/ABC234")
+    view |> element("button[phx-click='skip_name']") |> render_click()
+    html = render(view)
+    assert html =~ "You"
+    refute html =~ "(You)"
+  end
+
+  test "entering a custom name shows 'Name (You)' on current user's card", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/room/ABC234")
+    view |> element("form[phx-submit='set_name']") |> render_submit(%{"name" => "Alice"})
+    html = render(view)
+    assert html =~ "Alice (You)"
+  end
+
   test "leave room button navigates back to solo timer", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/room/ABC234")
     assert has_element?(view, "#leave-room-btn")


### PR DESCRIPTION
This pull request introduces improvements to the user display logic in the `RoomLive` module, specifically enhancing how a user's custom name is shown in the room member list. The main changes focus on tracking whether a user has set a custom display name and updating the UI accordingly.

<img width="809" height="480" alt="Screenshot 2026-02-21 at 22 27 54" src="https://github.com/user-attachments/assets/bddb244a-f03c-4305-ac7e-d18e7fd80987" />

<img width="823" height="433" alt="Screenshot 2026-02-21 at 22 28 49" src="https://github.com/user-attachments/assets/138963a8-9046-4ad9-9ab1-2d35c11c6ed3" />


Enhancements to user display name handling:

* Added a new `has_custom_name` assign to the socket, which tracks whether the user has set a custom display name. (`lib/tomato_web/live/room_live.ex`)
* Updated the logic in the member list rendering to show "You" if the current user has not set a custom name, and "`display_name` (You)" if they have. (`lib/tomato_web/live/room_live.ex`)
* Modified the event handler for setting a display name to update the `has_custom_name` assign based on whether the name is non-empty. (`lib/tomato_web/live/room_live.ex`)